### PR TITLE
CPP-38097 build gmp for generic x86_64 to make it compatible with older CPUs

### DIFF
--- a/linux/gmp/PKGBUILD
+++ b/linux/gmp/PKGBUILD
@@ -18,6 +18,7 @@ build() {
 
   ../${pkgname}-${pkgver}/configure \
     --prefix=${PREFIX} \
+    --build=x86_64-pc-linux-gnu \    
     --enable-static \
     --disable-shared
 

--- a/linux/gmp/PKGBUILD
+++ b/linux/gmp/PKGBUILD
@@ -18,7 +18,7 @@ build() {
 
   ../${pkgname}-${pkgver}/configure \
     --prefix=${PREFIX} \
-    --build=x86_64-pc-linux-gnu \    
+    --build=${CHOST} \
     --enable-static \
     --disable-shared
 


### PR DESCRIPTION
Without --build, ./configure uses the output from running ./config.guess. On buildserver this produced
"skylake-pc-linux-gnu". In this configuration gmp uses LZCNT instruction which is not present on older CPUs. When CPU without LZCNT support runs this code, the BSR instruction is executed instead. BSR produces a different result from LZCNT which triggers the assertion.