### PR TITLE
CPP-49753 [docker]: Split mingw image; align aarch64 toolchain flags

### DIFF
--- a/.teamcity-runtime-params/cidr/buildenv-images.properties
+++ b/.teamcity-runtime-params/cidr/buildenv-images.properties
@@ -1,0 +1,5 @@
+
+clion.bundle.docker.image.linux=registry.jetbrains.team/p/clion/containers/pkgbuild-linux-centos-7:6-amd64-staging-3-arm64-staging
+clion.bundle.docker.image.mingw=registry.jetbrains.team/p/clion/containers/pkgbuild-mingw:6-amd64-staging
+clion.bundle.docker.image.mingw-toolchain=registry.jetbrains.team/p/clion/containers/pkgbuild-mingw-toolchain:1-amd64-staging
+clion.bundle.docker.image.aarch64-mingw=registry.jetbrains.team/p/clion/containers/pkgbuild-aarch64-mingw-windows-arm64:6-amd64-staging

--- a/dockerfiles/mingw-toolchain.Dockerfile
+++ b/dockerfiles/mingw-toolchain.Dockerfile
@@ -1,10 +1,9 @@
-# Ubuntu-based image with makepkg, ccache and posix-threaded mingw-w64
-# toolchain for building PKGBUILD packages whose deliverables include
-# C++ ports (gdb, lldb, mingw-w64-runtime DLLs).
+# Ubuntu-based image with xPack mingw-w64 GCC for building the GCC 15
+# MinGW toolchain itself. Used ONLY by the MingwToolchain build, which
+# compiles binutils/make/gcc — pure C; no C++ standard library.
 #
-# The MingwToolchain build (binutils/make/gcc — pure C; needs to compile
-# GCC 15's libgcc, which Ubuntu's GCC 13 mingw cannot) uses a separate
-# image: mingw-toolchain.Dockerfile / pkgbuild-mingw-toolchain.
+# Other mingw-w64 builds (gdb, lldb, runtime DLLs) need posix-threaded
+# host mingw and use mingw.Dockerfile / pkgbuild-mingw.
 
 FROM ubuntu:24.04
 
@@ -39,21 +38,19 @@ RUN apt-get update \
       git \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Ubuntu's gcc-mingw-w64 ships two threading variants per host triple
-# (-posix and -win32) selected via update-alternatives. The default points
-# at -win32, whose gthr-default.h doesn't define __gthread_cond_t — any
-# C++ that includes <mutex>/<condition_variable> fails to compile under
-# GCC 14+. Switch to -posix so gdb/lldb and other C++ ports build.
-RUN apt-get update \
- && apt-get -y install \
-      gcc-mingw-w64 \
-      g++-mingw-w64 \
-      mingw-w64-tools \
- && apt-get clean && rm -rf /var/lib/apt/lists/* \
- && update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix \
- && update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix \
- && update-alternatives --set i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix \
- && update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
+# xPack GCC 14.3 cross-compiler instead of Ubuntu's GCC 13-based packages.
+# Ubuntu 24.04 ships gcc-mingw-w64 based on GCC 13, which cannot compile
+# GCC 15's libgcc (missing __builtin_stack_address, newer cpuid.h constants).
+# xPack 14.3 is win32-threaded — fine here because the toolchain build
+# compiles only C (binutils, make, gcc), no C++ that touches std::mutex.
+ARG XPACK_MINGW_GCC_VERSION=14.3.0-1
+ARG XPACK_MINGW_GCC_SHA256=7679c2f81dfb564479f7158dc99751fe03efd3ce03dbfd8372f1e0feb21fcfd4
+RUN curl -fsSL -o /tmp/xpack-mingw.tar.gz \
+      "https://github.com/xpack-dev-tools/mingw-w64-gcc-xpack/releases/download/v${XPACK_MINGW_GCC_VERSION}/xpack-mingw-w64-gcc-${XPACK_MINGW_GCC_VERSION}-linux-x64.tar.gz" \
+ && echo "${XPACK_MINGW_GCC_SHA256}  /tmp/xpack-mingw.tar.gz" | sha256sum -c - \
+ && tar xzf /tmp/xpack-mingw.tar.gz -C /opt/ \
+ && rm /tmp/xpack-mingw.tar.gz
+ENV PATH="/opt/xpack-mingw-w64-gcc-${XPACK_MINGW_GCC_VERSION}/bin:${PATH}"
 
 RUN apt-get update \
  && apt-get -y install \

--- a/mingw/makepkg-aarch64-w64-mingw32.conf
+++ b/mingw/makepkg-aarch64-w64-mingw32.conf
@@ -10,9 +10,16 @@ CHOST="aarch64-w64-mingw32"
 #-- Compiler and Linker Flags
 # -march (or -mcpu) builds exclusively for an architecture
 # -mtune optimizes for an architecture, but builds for whole processor family
-CPPFLAGS="-march=armv8-a -D_FORTIFY_SOURCE=2 -D__USE_MINGW_ANSI_STDIO=1"
+#
+# No -D_FORTIFY_SOURCE=2 here: LLVM-mingw aarch64 defines the *_chk
+# overlays in <string.h>/<stdio.h> but only ships their runtime symbols
+# (__memcpy_chk, __strcpy_chk, ...) in libssp — and many configure
+# probes (gmp's GMP_PROG_CC_WORKS, in particular) test-compile a memcpy
+# call WITHOUT $LDFLAGS, so -lssp never reaches the probe and link
+# fails with "undefined reference to __memcpy_chk". Drop FORTIFY here.
+CPPFLAGS="-march=armv8-a -D__USE_MINGW_ANSI_STDIO=1"
 # -O2+: https://github.com/llvm/llvm-project/issues/54753
-CFLAGS="-march=armv8-a -mtune=generic -O1 -pipe -lssp"
+CFLAGS="-march=armv8-a -mtune=generic -O1 -pipe"
 CXXFLAGS="$CFLAGS"
 LDFLAGS="-pipe -lssp"
 # Uncomment to enable hardening (ASLR, High entropy ASLR, DEP)

--- a/mingw/mingw-w64-runtime/PKGBUILD
+++ b/mingw/mingw-w64-runtime/PKGBUILD
@@ -15,13 +15,22 @@ md5sums=('3edacf7e64e1b7a634666ac043f6b13c')
 package() {
   install -dm755 ${pkgdir}${PREFIX}/bin
 
-  install -m755 -t ${pkgdir}${PREFIX}/bin/ $(
-    if [ $CARCH = aarch64 ]; then
-      echo "$CROSS_ROOT/$CROSS_TRIPLE/bin/"{libc++,libssp-0,libunwind}.dll
-    else
-      echo "$($CHOST-gcc -print-sysroot)/mingw/bin/"{libgcc*-1,libssp-0,libstdc++-6,libwinpthread-1}.dll
-    fi
-  )
+  if [ $CARCH = aarch64 ]; then
+    install -m755 -t ${pkgdir}${PREFIX}/bin/ \
+      "$CROSS_ROOT/$CROSS_TRIPLE/bin/"{libc++,libssp-0,libunwind}.dll
+  else
+    # `gcc -print-file-name` resolves runtime DLLs portably across mingw
+    # layouts: Ubuntu (split <chost>/lib + lib/gcc/<chost>/<ver>/), xPack
+    # (baked sysroot, <chost>/{bin,lib}/), MSYS2/Fedora (<sysroot>/mingw/bin).
+    # libgcc_s file name varies by ABI (libgcc_s_seh-1.dll on x86_64,
+    # libgcc_s_dw2-1.dll on i686), so glob in the libgcc directory.
+    local libgcc_dir="$(dirname "$($CHOST-gcc -print-libgcc-file-name)")"
+    install -m755 -t ${pkgdir}${PREFIX}/bin/ \
+      "$($CHOST-gcc -print-file-name=libwinpthread-1.dll)" \
+      "$($CHOST-gcc -print-file-name=libssp-0.dll)" \
+      "$($CHOST-gcc -print-file-name=libstdc++-6.dll)" \
+      "$libgcc_dir/"libgcc_s_*-1.dll
+  fi
 
   install -Dm644 "${srcdir}/COPYING.MinGW-w64-runtime.txt" "${pkgdir}${PREFIX}/share/licenses/${pkgname}/COPYING"
 }


### PR DESCRIPTION
Add a dedicated xPack 14.3 image for the MingwToolchain build (the
only consumer that needs xPack's GCC 14, because it cross-compiles
GCC 15's libgcc which Ubuntu's GCC 13 mingw cannot). Move every other
mingw port back to a posix-threaded host: xPack is win32-threaded and
its libstdc++ omits __gthread_cond_t, which breaks any C++ that
includes <mutex> — gdb and lldb stopped building.

Drop -D_FORTIFY_SOURCE=2 and -lssp from the aarch64 makepkg config.
LLVM-mingw aarch64 keeps the FORTIFY_SOURCE *_chk runtime symbols in
libssp only, but standard configure probes (notably gmp's
GMP_PROG_CC_WORKS) don't propagate LDFLAGS to test compiles, so these
flags reject the compiler instead of hardening it. -lssp in CFLAGS
also trips clang's -Wunused-command-line-argument under -Werror.

Resolve the runtime DLLs in mingw-w64-runtime via gcc -print-file-name
so the same PKGBUILD works against Ubuntu, xPack, and MSYS2 layouts
without per-toolchain branching.

Pin docker image tags via a runtime-params file so TeamCity DSL can
target each image and override at run time.
