### PR TITLE
Revert "CPP-45129 [mingw]: Various fixes for mingw toolchain build"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -487,20 +487,11 @@ do_bundle() {
     message 'Removing l10n files...'
     rm -rvf ${PREFIX#/}/share/locale
 
-    if [[ -z "${KEEP_DEV_FILES:-}" ]]; then
-        message 'Removing leftover development files...'
-        find_and_rm  ${PREFIX#/} ! -type d -name "*.a"
-        find_and_rm  ${PREFIX#/} ! -type d -name "*.la"
-        rm -rvf ${PREFIX#/}/lib/pkgconfig
-        rm -rvf ${PREFIX#/}/include
-    fi
-
-    # Per-flavor bundle shaping (extract extra makedepends payload, relocate
-    # files where downstream consumers expect them, etc.).  Defined by
-    # ${MAKEPKG_CONF} when needed; absent for vanilla flavors.
-    if declare -F finalize_bundle >/dev/null; then
-        execute 'finalize_bundle' finalize_bundle
-    fi
+    message 'Removing leftover development files...'
+    find_and_rm  ${PREFIX#/} ! -type d -name "*.a"
+    find_and_rm  ${PREFIX#/} ! -type d -name "*.la"
+    rm -rvf ${PREFIX#/}/lib/pkgconfig
+    rm -rvf ${PREFIX#/}/include
 
     # Remove empty directories
     find ${PREFIX#/} -depth -type d -exec rmdir '{}' \; 2>/dev/null

--- a/mingw/gmp/PKGBUILD
+++ b/mingw/gmp/PKGBUILD
@@ -41,5 +41,4 @@ build() {
 package_gmp() {
   cd "${srcdir}/build-${CHOST}"
   make DESTDIR="${pkgdir}" install
-  install_copying
 }

--- a/mingw/gmp/PKGBUILD.template
+++ b/mingw/gmp/PKGBUILD.template
@@ -39,5 +39,4 @@ build() {
 package_gmp() {
   cd "${srcdir}/build-${CHOST}"
   make DESTDIR="${pkgdir}" install
-  install_copying
 }

--- a/mingw/makepkg-mingw.conf.inc
+++ b/mingw/makepkg-mingw.conf.inc
@@ -1,13 +1,5 @@
 PREFIX=${PREFIX-/win}
 
-# Keep static archives, libtool archives, pkgconfig and the toolchain include
-# tree in the bundle.  On Windows the *.a/*.dll.a files are not just static
-# libs — they are import libs the linker needs to resolve every -l<name> flag
-# (Win32: -lkernel32, -luser32, ...; GCC runtime: -lstdc++, -lssp, -latomic,
-# -lgomp, -lwinpthread, ...).  Without them the bundled toolchain cannot link
-# anything at all.
-KEEP_DEV_FILES=1
-
 _makepkg_mingw_conf_name="${BASH_SOURCE}"
 
 source $(dirname ${_makepkg_mingw_conf_name})/../makepkg.conf.inc
@@ -100,44 +92,6 @@ install_copying() {
 	find "${srcdir}" -type f -name "COPYING*" | while read c; do
 		install -Dm644 -t "${pkgdir}${PREFIX}/licenses/${pkgname}" "${c}"
 	done
-}
-
-# Hook called by build.sh do_bundle() inside ${BUNDLE_DIR} to apply mingw-only
-# shaping to the extracted prefix tree before archiving.  Two responsibilities:
-#
-#   1. Bring in payload from packages that are otherwise makedepends-only.
-#      The bundled toolchain needs:
-#        - manifest:           default-manifest.o (referenced by gcc specs at
-#                              link time for every produced executable)
-#        - zlib, libiconv:     headers + static libs that gcc/binutils were
-#                              built against; users compiling against the
-#                              cross-toolchain expect them in the sysroot
-#        - gmp, mpc, mpfr:     statically linked into gcc; their COPYING
-#                              files must travel with the bundle (LGPL/GPL)
-#
-#   2. Relocate libgcc_s files so gcc's specs find them.  Upstream installs
-#      libgcc_s_seh-1.dll under lib/gcc/${CHOST}/ and libgcc_s.a under
-#      lib/gcc/${CHOST}/lib/, but gcc's compiled-in spec searches the
-#      version-numbered subdir for the import lib and Windows DLL search
-#      finds the runtime DLL via PATH (so it has to live in bin/).
-finalize_bundle() {
-	local package
-	for package in manifest zlib libiconv gmp mpc mpfr; do
-		execute "extract (makedep)" \
-			bsdtar -xvf "${PKGDEST}/$(pkgfilename)" ${PREFIX#/}
-	done
-	unset package
-
-	local gcc_libdir="${PREFIX#/}/lib/gcc/${CHOST}"
-	local gcc_ver_libdir
-	gcc_ver_libdir=$(ls -d "${gcc_libdir}"/[0-9]*.[0-9]*.[0-9]* 2>/dev/null | head -n1)
-	if [[ -n "${gcc_ver_libdir}" && -f "${gcc_libdir}/lib/libgcc_s.a" ]]; then
-		mv -v "${gcc_libdir}/lib/libgcc_s.a" "${gcc_ver_libdir}/"
-		rmdir "${gcc_libdir}/lib" 2>/dev/null || true
-	fi
-	if [[ -f "${gcc_libdir}/libgcc_s_seh-1.dll" ]]; then
-		mv -v "${gcc_libdir}/libgcc_s_seh-1.dll" "${PREFIX#/}/bin/"
-	fi
 }
 
 # vim: set ft=sh ts=2 sw=2 et:

--- a/mingw/mpfr/PKGBUILD
+++ b/mingw/mpfr/PKGBUILD
@@ -35,5 +35,4 @@ build() {
 package_mpfr() {
   cd "${srcdir}/build-${CHOST}"
   make DESTDIR="${pkgdir}" install
-  install_copying
 }

--- a/mingw/mpfr/PKGBUILD.template
+++ b/mingw/mpfr/PKGBUILD.template
@@ -33,5 +33,4 @@ build() {
 package_mpfr() {
   cd "${srcdir}/build-${CHOST}"
   make DESTDIR="${pkgdir}" install
-  install_copying
 }


### PR DESCRIPTION
To fix builds on TeamCity.

This reverts commit b09f5bebdc334aade619c85c93d90161bc6951b4.